### PR TITLE
Okta Security Improvement

### DIFF
--- a/src/Mvp.Selections.Api/Clients/OktaClient.cs
+++ b/src/Mvp.Selections.Api/Clients/OktaClient.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Mvp.Selections.Api.Configuration;
 using Mvp.Selections.Api.Model.Auth;
@@ -13,25 +15,41 @@ namespace Mvp.Selections.Api.Clients
 
         private readonly OktaClientOptions _options;
 
-        public OktaClient(HttpClient client, IOptions<OktaClientOptions> options)
+        private readonly IMemoryCache _cache;
+
+        public OktaClient(HttpClient client, IOptions<OktaClientOptions> options, IMemoryCache cache)
         {
             _client = client;
             _options = options.Value;
+            _cache = cache;
         }
 
         public async Task<bool> IsValidAsync(string token)
         {
-            FormUrlEncodedContent reqContent = new (new[]
+            bool result;
+            if (_cache.TryGetValue(token, out bool isValid))
             {
-                new KeyValuePair<string, string>("token", token),
-                new KeyValuePair<string, string>("token_type_hint", "id_token"),
-                new KeyValuePair<string, string>("client_id", _options.ClientId),
-                new KeyValuePair<string, string>("client_secret", _options.ClientSecret)
-            });
-            HttpResponseMessage response = await _client.PostAsync(_options.ValidationEndpoint, reqContent);
-            IntrospectionResponse introspectionResponse = await response.Content.ReadAsAsync<IntrospectionResponse>();
+                result = isValid;
+            }
+            else
+            {
+                FormUrlEncodedContent reqContent = new (new[]
+                {
+                    new KeyValuePair<string, string>("token", token),
+                    new KeyValuePair<string, string>("token_type_hint", "id_token"),
+                    new KeyValuePair<string, string>("client_id", _options.ClientId),
+                    new KeyValuePair<string, string>("client_secret", _options.ClientSecret)
+                });
+                HttpResponseMessage response = await _client.PostAsync(_options.ValidationEndpoint, reqContent);
+                IntrospectionResponse introspectionResponse = await response.Content.ReadAsAsync<IntrospectionResponse>();
 
-            return introspectionResponse.Active;
+                result =
+                    introspectionResponse.Active
+                    && (introspectionResponse.Issuer?.Equals(_options.ValidIssuer, StringComparison.InvariantCultureIgnoreCase) ?? false);
+                _cache.Set(token, result, TimeSpan.FromSeconds(_options.CacheDuration));
+            }
+
+            return result;
         }
     }
 }

--- a/src/Mvp.Selections.Api/Configuration/OktaClientOptions.cs
+++ b/src/Mvp.Selections.Api/Configuration/OktaClientOptions.cs
@@ -10,6 +10,10 @@ namespace Mvp.Selections.Api.Configuration
 
         public string ClientSecret { get; set; }
 
-        public Uri ValidationEndpoint { get; set; }
+        public Uri ValidationEndpoint { get; set; } = new ("https://externalsitecore.oktapreview.com/oauth2/default/v1/introspect");
+
+        public string ValidIssuer { get; set; } = "https://externalsitecore.oktapreview.com/oauth2/default";
+
+        public short CacheDuration { get; set; } = 10;
     }
 }


### PR DESCRIPTION
+ Added validation of the Okta Issuer of a token
+ Token validation is now cached for configurable amount of seconds to speed up multiple calls in short timespan (default 10 seconds)