### PR TITLE
Fixed GetAllApplications for Reviewer

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@
 # Add steps that publish symbols, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/aspnet/build-aspnet-4
 
-name: 4.4.1$(Rev:.r)
+name: 4.4.2$(Rev:.r)
 
 trigger:
 - main

--- a/src/Mvp.Selections.Api/Services/ApplicationService.cs
+++ b/src/Mvp.Selections.Api/Services/ApplicationService.cs
@@ -174,12 +174,15 @@ namespace Mvp.Selections.Api.Services
                 _logger.LogInformation(message);
             }
 
-            IList<Application> existingApplications = await _applicationRepository.GetAllForUserReadOnlyAsync(newApplication.Applicant.Id, selectionId);
-            if (existingApplications.Any())
+            if (newApplication.Applicant != null)
             {
-                string message = $"Can not submit multiple applications to Selection '{selectionId}'.";
-                result.Messages.Add(message);
-                _logger.LogInformation(message);
+                IList<Application> existingApplications = await _applicationRepository.GetAllForUserReadOnlyAsync(newApplication.Applicant.Id, selectionId);
+                if (existingApplications.Any())
+                {
+                    string message = $"Can not submit multiple applications to Selection '{selectionId}'.";
+                    result.Messages.Add(message);
+                    _logger.LogInformation(message);
+                }
             }
 
             if (result.Messages.Count == 0)
@@ -481,8 +484,8 @@ namespace Mvp.Selections.Api.Services
             else if (user.HasRight(Right.Review))
             {
                 result = isReadOnly ?
-                    await _applicationRepository.GetAllForReviewReadOnlyAsync(user.Roles.OfType<SelectionRole>(), selectionId, countryId, status, page, pageSize, includes ?? _standardIncludes) :
-                    await _applicationRepository.GetAllForReviewAsync(user.Roles.OfType<SelectionRole>(), selectionId, countryId, status, page, pageSize, includes ?? _standardIncludes);
+                    await _applicationRepository.GetAllForReviewReadOnlyAsync(user.Roles.OfType<SelectionRole>(), userId, selectionId, countryId, status, page, pageSize, includes ?? _standardIncludes) :
+                    await _applicationRepository.GetAllForReviewAsync(user.Roles.OfType<SelectionRole>(), userId, selectionId, countryId, status, page, pageSize, includes ?? _standardIncludes);
             }
             else if (user.HasRight(Right.Apply))
             {

--- a/src/Mvp.Selections.Data/Repositories/ApplicationRepository.cs
+++ b/src/Mvp.Selections.Data/Repositories/ApplicationRepository.cs
@@ -26,14 +26,14 @@ namespace Mvp.Selections.Data.Repositories
             return await GetAllQuery(userId, selectionId, countryId, status, page, pageSize, includes).AsNoTracking().ToListAsync();
         }
 
-        public async Task<IList<Application>> GetAllForReviewAsync(IEnumerable<SelectionRole> selectionRoles, Guid? selectionId = null, short? countryId = null, ApplicationStatus? status = null, int page = 1, short pageSize = 100, params Expression<Func<Application, object>>[] includes)
+        public async Task<IList<Application>> GetAllForReviewAsync(IEnumerable<SelectionRole> selectionRoles, Guid? userId = null, Guid? selectionId = null, short? countryId = null, ApplicationStatus? status = null, int page = 1, short pageSize = 100, params Expression<Func<Application, object>>[] includes)
         {
-            return await GetAllForReviewQuery(selectionRoles, selectionId, countryId, status, page, pageSize, includes).ToListAsync();
+            return await GetAllForReviewQuery(selectionRoles, userId, selectionId, countryId, status, page, pageSize, includes).ToListAsync();
         }
 
-        public async Task<IList<Application>> GetAllForReviewReadOnlyAsync(IEnumerable<SelectionRole> selectionRoles, Guid? selectionId = null, short? countryId = null, ApplicationStatus? status = null, int page = 1, short pageSize = 100, params Expression<Func<Application, object>>[] includes)
+        public async Task<IList<Application>> GetAllForReviewReadOnlyAsync(IEnumerable<SelectionRole> selectionRoles, Guid? userId = null, Guid? selectionId = null, short? countryId = null, ApplicationStatus? status = null, int page = 1, short pageSize = 100, params Expression<Func<Application, object>>[] includes)
         {
-            return await GetAllForReviewQuery(selectionRoles, selectionId, countryId, status, page, pageSize, includes).AsNoTracking().ToListAsync();
+            return await GetAllForReviewQuery(selectionRoles, userId, selectionId, countryId, status, page, pageSize, includes).AsNoTracking().ToListAsync();
         }
 
         public async Task<IList<Application>> GetAllForUserAsync(Guid userId, Guid? selectionId = null, ApplicationStatus? status = null, int page = 1, short pageSize = 100, params Expression<Func<Application, object>>[] includes)
@@ -46,7 +46,7 @@ namespace Mvp.Selections.Data.Repositories
             return await GetAllForUserQuery(userId, selectionId, status, page, pageSize, includes).AsNoTracking().ToListAsync();
         }
 
-        private static ExpressionStarter<Application> BuildForReviewPredicate(IEnumerable<SelectionRole> selectionRoles)
+        private static ExpressionStarter<Application> BuildForReviewPredicate(IEnumerable<SelectionRole> selectionRoles, Guid? userId)
         {
             ExpressionStarter<Application> result = PredicateBuilder.New<Application>();
             foreach (SelectionRole role in selectionRoles)
@@ -58,6 +58,11 @@ namespace Mvp.Selections.Data.Repositories
                     (role.ApplicationId == null || role.ApplicationId == a.Id) &&
                     (role.SelectionId == null || role.SelectionId == a.Selection.Id) &&
                     (role.RegionId == null || countryIds.Contains(a.Country.Id)));
+            }
+
+            if (userId != null)
+            {
+                result = result.Or(a => a.Applicant.Id == userId);
             }
 
             return result;
@@ -96,9 +101,9 @@ namespace Mvp.Selections.Data.Repositories
                 .Includes(includes);
         }
 
-        private IQueryable<Application> GetAllForReviewQuery(IEnumerable<SelectionRole> selectionRoles, Guid? selectionId, short? countryId, ApplicationStatus? status, int page, short pageSize, IEnumerable<Expression<Func<Application, object>>> includes)
+        private IQueryable<Application> GetAllForReviewQuery(IEnumerable<SelectionRole> selectionRoles, Guid? userId, Guid? selectionId, short? countryId, ApplicationStatus? status, int page, short pageSize, IEnumerable<Expression<Func<Application, object>>> includes)
         {
-            ExpressionStarter<Application> predicate = BuildForReviewPredicate(selectionRoles);
+            ExpressionStarter<Application> predicate = BuildForReviewPredicate(selectionRoles, userId);
             page--;
             IQueryable<Application> query = Context.Applications.AsExpandable();
             if (status != null)
@@ -114,6 +119,11 @@ namespace Mvp.Selections.Data.Repositories
             if (countryId != null)
             {
                 query = query.Where(a => a.Country.Id == countryId);
+            }
+
+            if (userId != null)
+            {
+                query = query.Where(a => a.Applicant.Id == userId);
             }
 
             return query

--- a/src/Mvp.Selections.Data/Repositories/Interfaces/IApplicationRepository.cs
+++ b/src/Mvp.Selections.Data/Repositories/Interfaces/IApplicationRepository.cs
@@ -10,9 +10,9 @@ namespace Mvp.Selections.Data.Repositories.Interfaces
 
         Task<IList<Application>> GetAllReadOnlyAsync(Guid? userId = null, Guid? selectionId = null, short? countryId = null, ApplicationStatus? status = null, int page = 1, short pageSize = 100, params Expression<Func<Application, object>>[] includes);
 
-        Task<IList<Application>> GetAllForReviewAsync(IEnumerable<SelectionRole> selectionRoles, Guid? selectionId = null, short? countryId = null, ApplicationStatus? status = null, int page = 1, short pageSize = 100, params Expression<Func<Application, object>>[] includes);
+        Task<IList<Application>> GetAllForReviewAsync(IEnumerable<SelectionRole> selectionRoles, Guid? userId = null, Guid? selectionId = null, short? countryId = null, ApplicationStatus? status = null, int page = 1, short pageSize = 100, params Expression<Func<Application, object>>[] includes);
 
-        Task<IList<Application>> GetAllForReviewReadOnlyAsync(IEnumerable<SelectionRole> selectionRoles, Guid? selectionId = null, short? countryId = null, ApplicationStatus? status = null, int page = 1, short pageSize = 100, params Expression<Func<Application, object>>[] includes);
+        Task<IList<Application>> GetAllForReviewReadOnlyAsync(IEnumerable<SelectionRole> selectionRoles, Guid? userId = null, Guid? selectionId = null, short? countryId = null, ApplicationStatus? status = null, int page = 1, short pageSize = 100, params Expression<Func<Application, object>>[] includes);
 
         Task<IList<Application>> GetAllForUserAsync(Guid userId, Guid? selectionId = null, ApplicationStatus? status = null, int page = 1, short pageSize = 100, params Expression<Func<Application, object>>[] includes);
 


### PR DESCRIPTION
+ ApplicationRepository now accepts userId filter on GetAllForReviewAsync and GetAllForReviewReadOnlyAsync
+ Fixed issue where PredicateBuilder would return false if no SelectionRoles available and trying to fetch Applications by userId
+ Fixed nullref when posting Application with no Country selected in profile
+ Fixes Sitecore/XM-Cloud-Introduction#249