### PR TITLE
Fixed Remove Review

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@
 # Add steps that publish symbols, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/aspnet/build-aspnet-4
 
-name: 4.9.0$(Rev:.r)
+name: 4.9.1$(Rev:.r)
 
 trigger:
 - main

--- a/src/Mvp.Selections.Api/Configuration/OpenApiConfigurationOptions.cs
+++ b/src/Mvp.Selections.Api/Configuration/OpenApiConfigurationOptions.cs
@@ -10,7 +10,7 @@ namespace Mvp.Selections.Api.Configuration
     {
         public OpenApiInfo Info { get; set; } = new ()
         {
-            Version = "4.9.0",
+            Version = "4.9.1",
             Title = "Sitecore MVP Selections API",
             Description = "Supporting API for the Sitecore MVP Selection process.",
             Contact = new OpenApiContact

--- a/src/Mvp.Selections.Api/Services/ReviewService.cs
+++ b/src/Mvp.Selections.Api/Services/ReviewService.cs
@@ -292,7 +292,9 @@ namespace Mvp.Selections.Api.Services
             Review existingReview = await _reviewRepository.GetAsync(id, _standardIncludes);
             if (existingReview != null && (user.HasRight(Right.Admin) || (existingReview.Reviewer.Id == user.Id && existingReview.Status != ReviewStatus.Finished)))
             {
-                if (await _reviewRepository.RemoveReviewScoreCategoriesAsync(id) || await _reviewRepository.RemoveAsync(id))
+                bool removedReviewScoreCategories = await _reviewRepository.RemoveReviewScoreCategoriesAsync(id);
+                bool removedReview = await _reviewRepository.RemoveAsync(id);
+                if (removedReviewScoreCategories || removedReview)
                 {
                     await _reviewRepository.SaveChangesAsync();
                     result.StatusCode = HttpStatusCode.NoContent;


### PR DESCRIPTION
+ Remove review would only partially execute due to if statement code execution optimalization behaviour. Split the execution and the evaluation to ensure both removals are executed during the same run.
+ Bumped to version v4.9.1