### PR TITLE
Fix "vanishing" results

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,12 +11,12 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
@@ -27,12 +27,12 @@
     <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.32.0" />
+    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.33.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="xunit" Version="2.8.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
   <ItemGroup Label="Global Project Tooling">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@
 # Add steps that publish symbols, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/aspnet/build-aspnet-4
 
-name: 4.15.0$(Rev:.r)
+name: 4.15.1$(Rev:.r)
 
 trigger:
 - main

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,6 @@
   <!--<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />-->
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Mvp.Selections.Api/Mvp.Selections.Api.csproj
+++ b/src/Mvp.Selections.Api/Mvp.Selections.Api.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);1591</NoWarn>

--- a/src/Mvp.Selections.Api/Services/Interfaces/IMvpProfileService.cs
+++ b/src/Mvp.Selections.Api/Services/Interfaces/IMvpProfileService.cs
@@ -8,6 +8,12 @@ namespace Mvp.Selections.Api.Services.Interfaces
 {
     public interface IMvpProfileService
     {
+        public const string TypeFacetIdentifier = "type";
+
+        public const string YearFacetIdentifier = "year";
+
+        public const string CountryFacetIdentifier = "country";
+
         Task<OperationResult<MvpProfile>> GetMvpProfileAsync(Guid id);
 
         Task<SearchOperationResult<MvpProfile>> SearchMvpProfileAsync(

--- a/src/Mvp.Selections.Api/Services/UserService.cs
+++ b/src/Mvp.Selections.Api/Services/UserService.cs
@@ -378,7 +378,7 @@ namespace Mvp.Selections.Api.Services
 
         private static SearchFacet CalculateYearFacet(IEnumerable<MvpProfile> profiles)
         {
-            SearchFacet result = new() { Identifier = "year" };
+            SearchFacet result = new() { Identifier = IMvpProfileService.YearFacetIdentifier };
             foreach (Title title in profiles.SelectMany(p => p.Titles))
             {
                 string key = title.Application.Selection.Year.ToString();
@@ -393,7 +393,7 @@ namespace Mvp.Selections.Api.Services
 
         private static SearchFacet CalculateTypeFacet(IReadOnlyCollection<MvpProfile> profiles)
         {
-            SearchFacet result = new() { Identifier = "type" };
+            SearchFacet result = new() { Identifier = IMvpProfileService.TypeFacetIdentifier };
             List<MvpType> distinctTypes = profiles
                 .SelectMany(p => p.Titles.Select(t => t.MvpType))
                 .Distinct(new IdEqualityComparer<MvpType, short>())
@@ -414,7 +414,7 @@ namespace Mvp.Selections.Api.Services
 
         private static SearchFacet CalculateCountryFacet(IEnumerable<MvpProfile> profiles)
         {
-            SearchFacet result = new() { Identifier = "country" };
+            SearchFacet result = new() { Identifier = IMvpProfileService.CountryFacetIdentifier };
             foreach (Country? country in profiles.Select(p => p.Country))
             {
                 if (country != null && !result.Options.TryAdd(country.Id.ToString(), new SearchFacetOption { Identifier = country.Id.ToString(), Display = country.Name, Count = 1 }, o => o.Identifier))

--- a/src/Mvp.Selections.Client/Mvp.Selections.Client.csproj
+++ b/src/Mvp.Selections.Client/Mvp.Selections.Client.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <Title>MVP Selections API Client</Title>
     <Authors>sc-ivanlieckens</Authors>
     <Company>Sitecore</Company>

--- a/src/Mvp.Selections.Data/Mvp.Selections.Data.csproj
+++ b/src/Mvp.Selections.Data/Mvp.Selections.Data.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 

--- a/src/Mvp.Selections.Data/Repositories/UserRepository.cs
+++ b/src/Mvp.Selections.Data/Repositories/UserRepository.cs
@@ -193,7 +193,7 @@ namespace Mvp.Selections.Data.Repositories
 
             if (countryIds != null)
             {
-                query = countryIds.Aggregate(query, (current, id) => current.Where(u => u.Applications.Where(a => a.Title != null).Any(a => a.Country.Id == id)));
+                query = countryIds.Aggregate(query, (current, id) => current.Where(u => u.Applications.Where(a => a.Title != null).Any(a => a.Country.Id == id) || u.Country!.Id == id));
             }
 
             return query

--- a/src/Mvp.Selections.Domain/Mvp.Selections.Domain.csproj
+++ b/src/Mvp.Selections.Domain/Mvp.Selections.Domain.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 

--- a/tests/Mvp.Selections.Api.Tests/Services/UserServiceTests.cs
+++ b/tests/Mvp.Selections.Api.Tests/Services/UserServiceTests.cs
@@ -1,0 +1,65 @@
+﻿using AutoFixture.Xunit2;
+using FluentAssertions;
+using Mvp.Selections.Api.Cache;
+using Mvp.Selections.Api.Model;
+using Mvp.Selections.Api.Model.Request;
+using Mvp.Selections.Api.Services;
+using Mvp.Selections.Api.Services.Interfaces;
+using Mvp.Selections.Domain;
+using Mvp.Selections.Tests.Utilities;
+using NSubstitute;
+using Xunit;
+
+namespace Mvp.Selections.Api.Tests.Services
+{
+    public class UserServiceTests
+    {
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task SearchMvpProfileAsync_FacetCountValidation([Frozen] ICacheManager cache, UserService sut, MvpProfile mvp1, MvpProfile mvp2, MvpProfile mvp3, Country country1, Country country2, MvpType type1)
+        {
+            // Arrange
+            mvp1.Country = country1;
+            mvp1.Titles.Clear();
+            mvp1.Titles.Add(new Title(Guid.NewGuid())
+            {
+                MvpType = type1,
+                Application = new Application(Guid.NewGuid())
+                    { Selection = new Selection(Guid.NewGuid()) { Year = 1800 } }
+            });
+
+            mvp2.Country = country1;
+            mvp2.Titles.Clear();
+            mvp2.Titles.Add(new Title(Guid.NewGuid())
+            {
+                MvpType = type1,
+                Application = new Application(Guid.NewGuid())
+                    { Selection = new Selection(Guid.NewGuid()) { Year = 1801 } }
+            });
+
+            mvp3.Country = country2;
+            mvp3.Titles.Clear();
+            mvp3.Titles.Add(new Title(Guid.NewGuid())
+            {
+                MvpType = type1,
+                Application = new Application(Guid.NewGuid())
+                    { Selection = new Selection(Guid.NewGuid()) { Year = 1803 } }
+            });
+
+            cache.TryGet(Arg.Any<string>(), out Arg.Any<List<MvpProfile>?>()).Returns(x =>
+            {
+                x[1] = new List<MvpProfile> { mvp1, mvp2, mvp3 };
+                return true;
+            });
+
+            // Act
+            SearchOperationResult<MvpProfile> result = await sut.SearchMvpProfileAsync();
+
+            // Assert
+            result.Result.TotalResults.Should().Be(3);
+            result.Result.Facets.Single(f => f.Identifier == IMvpProfileService.CountryFacetIdentifier).Options.Should().HaveCount(2);
+            result.Result.Facets.Single(f => f.Identifier == IMvpProfileService.TypeFacetIdentifier).Options.Should().HaveCount(1);
+            result.Result.Facets.Single(f => f.Identifier == IMvpProfileService.YearFacetIdentifier).Options.Should().HaveCount(3);
+        }
+    }
+}


### PR DESCRIPTION
+ Since users' countries are displayed instead of application countries it is possible to have users in a non-filtered result being counted towards a country that when filtered they don't show up for, this is resolved by OR with the user's country when filtering
+ Added facet count test
+ Updated NuGet packages
+ Fixed NetFramework target for running isolated mode in Azure Functions

Special thanks to @marcelgruber